### PR TITLE
[16.0][FIX] account_invoice_fixed_discount: fix missing discount % value

### DIFF
--- a/account_invoice_fixed_discount/reports/report_account_invoice.xml
+++ b/account_invoice_fixed_discount/reports/report_account_invoice.xml
@@ -1,43 +1,55 @@
 <!-- Copyright 2017 ForgeFlow S.L.
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
-        <xpath expr="//t[@t-set='display_discount']" position="after">
+    <template
+        id="report_invoice_document"
+        inherit_id="account.report_invoice_document"
+        priority="99"
+    >
+        <xpath expr="//t[@t-set='display_discount']" position="replace">
+            <t
+                t-set="display_discount"
+                t-value="any(l.discount for l in o.invoice_line_ids) or any(l.discount_fixed for l in o.invoice_line_ids)"
+            />
             <t
                 t-set="display_discount_fixed"
-                t-value="any([l.discount_fixed for l in o.invoice_line_ids])"
+                t-value="any(l.discount_fixed for l in o.invoice_line_ids)"
             />
         </xpath>
-        <xpath expr="//th[@name='th_price_unit']" position="attributes">
-            <attribute name="t-if" add="display_discount_fixed" separator=" or " />
-        </xpath>
-        <xpath expr="//th[@name='th_price_unit']/span" position="attributes">
-            <attribute name="t-if" add="not display_discount_fixed" separator=" or " />
+
+        <xpath expr="//th[@name='th_price_unit']" position="replace">
+            <th
+                name="th_price_unit"
+                t-if="display_discount"
+                t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
+            >
+                <t t-if="display_discount_fixed">
+                    <span>Discount Amount (%)</span>
+                </t>
+                <t t-else="">
+                    <span>Disc.%</span>
+                </t>
+            </th>
         </xpath>
 
-        <xpath expr="//th[@name='th_price_unit']/span" position="before">
-            <t t-if="display_discount_fixed">
-                <span>Discount Amount (%)</span>
-            </t>
-        </xpath>
-
-        <xpath expr="//span[@t-field='line.discount']/.." position="attributes">
-            <attribute name="t-if" add="display_discount_fixed" separator=" or " />
-        </xpath>
-        <xpath expr="//span[@t-field='line.discount']" position="attributes">
-            <attribute name="t-if" add="line.discount_fixed" separator=" or " />
-        </xpath>
-        <xpath expr="//span[@t-field='line.discount']" position="before">
-            <t t-if="display_discount_fixed and line.discount_fixed">
-                <span class="text-nowrap" t-field="line.discount_fixed" /><span
-                    class="text-nowrap"
-                > (or</span>
-            </t>
-        </xpath>
-        <xpath expr="//span[@t-field='line.discount']" position="after">
-            <t t-if="display_discount_fixed and line.discount_fixed"><span
-                    class="text-nowrap"
-                > %)</span></t>
+        <xpath
+            expr="//table[@name='invoice_line_table']//td[@t-if='display_discount']"
+            position="replace"
+        >
+            <td
+                t-if="display_discount"
+                t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
+            >
+                <t t-if="display_discount_fixed">
+                    <span class="text-nowrap" t-field="line.discount_fixed" />
+                    <span class="text-nowrap"> (or</span>
+                    <span class="text-nowrap" t-field="line.discount" />
+                    <span class="text-nowrap"> %)</span>
+                </t>
+                <t t-else="">
+                    <span class="text-nowrap" t-field="line.discount" />
+                </t>
+            </td>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
This commit fix following issue:

Steps to reproduce

*  Create or open a customer invoice with at least one invoice line and use the standard Odoo percentage discount field ( discount ), not the fixed discount field provided by the module.
*  Print the invoice report.

Expected result

* dics% field has value

Current result

* dics% field  is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Invoice PDF/HTML reports now show discount columns whenever any line has a fixed or percentage discount.
  * When both fixed and percentage discounts exist, the report displays fixed amounts with the corresponding percentage in parentheses.
  * Column headings adapt to the discount type shown and discount columns are hidden on small screens for improved responsive layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->